### PR TITLE
⚒  Fix preseason issues

### DIFF
--- a/src/app/components/CardList.jsx
+++ b/src/app/components/CardList.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { ColumnCSS, mediaQuery } from '../styles'
 import { TextCard, MatchCard } from './Card'
 import { SettingsConsumer } from './Context'
+import browser from '../utils/browser'
 
 
 const Wrapper = styled.div`
@@ -12,7 +13,8 @@ const Wrapper = styled.div`
 
     ${mediaQuery`
         min-height: 100px;
-        max-height: 250px;
+        padding: 0 5px 10px 5px;
+        ${(props) => (props.isPopup && 'max-height: 250px;')}
         overflow-y: scroll;
     `}
 `
@@ -47,8 +49,20 @@ const generateCards = (games, selected, favTeam, broadcast, rest) => {
 
 
 class CardList extends React.PureComponent {
+    constructor() {
+        super()
+        this.state = { isPopup: false }
+    }
+
+    componentDidMount() {
+        browser.tabs.getCurrent((tab) => {
+            this.setState({ isPopup: !tab })
+        })
+    }
+
     render() {
         const { games, isLoading, selected, ...rest} = this.props
+        const { isPopup } = this.state
         if (isLoading) {
             return (
                 <Wrapper>
@@ -67,7 +81,7 @@ class CardList extends React.PureComponent {
         return (
             <SettingsConsumer>
                 {({state: { team, broadcast }}) => (
-                    <Wrapper>
+                    <Wrapper isPopup={isPopup}>
                         {generateCards(games, selected, team, broadcast, rest)}
                     </Wrapper>
                 )}

--- a/src/app/components/Header.jsx
+++ b/src/app/components/Header.jsx
@@ -25,16 +25,16 @@ class Header extends React.Component {
                         label="Boxscores"
                     />
                     <TabItem
-                        to={getDestPath(pathname, '/options')}
-                        label="Options"
-                    />
-                    <TabItem
                         to={getDestPath(pathname, '/standings')}
                         label="Standings"
                     />
                     <TabItem
                         to={getDestPath(pathname, '/playoff')}
                         label="Playoff"
+                    />
+                    <TabItem
+                        to={getDestPath(pathname, '/options')}
+                        label="Options"
                     />
                 </Tab>
             </React.Fragment>

--- a/src/app/components/Layout.jsx
+++ b/src/app/components/Layout.jsx
@@ -39,14 +39,6 @@ class Layout extends React.Component {
     static Header = Header
     static Content = Content
 
-    constructor(props) {
-        super(props)
-
-        this.state = {
-            selectedIndex: 0,
-        }
-    }
-
     render() {
         const children = React.Children.map(
             this.props.children,
@@ -65,8 +57,5 @@ Layout.propTypes = {
     children: PropTypes.node,
 }
 
-Layout.defaultProps = {
-    playoff: <React.Fragment />,
-}
 
 export default Layout

--- a/src/app/components/Links.jsx
+++ b/src/app/components/Links.jsx
@@ -24,14 +24,10 @@ const Link = styled.a`
     cursor: pointer;
 `
 
-class Links extends React.Component {
-    renderLinks() {
-
-    }
-
+class Links extends React.PureComponent {
     render() {
-        const links = ['options', 'standings', 'playoff', 'box-scores']
-        const hrefs = ['options', 'standings', 'playoff', 'boxscores']
+        const links = ['box-scores', 'standings', 'playoff', 'options']
+        const hrefs = ['boxscores', 'standings', 'playoff', 'options']
         const atags = links.map((element, index) => (
             <SettingsConsumer key={`link-${index}`}>
                 {({ state: { dark } }) => (

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Row } from '../styles'
 import { SettingsConsumer } from '../components/Context'
 import { Theme } from '../styles'
+import {formatClock} from '../utils/format'
 
 
 const Wrapper = styled.div`
@@ -49,13 +50,7 @@ const renderStatusAndClock = (spoiler, status, clock, totalPeriod, gameStatus) =
     if (spoiler && gameStatus !== '1') {
         return ''
     }
-    if (status === 'Halftime') {
-        return 'Halftime'
-    } else if (status === 'Final' && totalPeriod > 4 ) {
-        return 'Final/OT'
-    } else {
-        return `${status} ${clock}`
-    }
+    return formatClock(clock, status) || status
 }
 
 class MatchInfo extends React.PureComponent {
@@ -109,17 +104,17 @@ MatchInfo.propTypes = {
         abbreviation: PropTypes.string.isRequired,
         city: PropTypes.string.isRequired,
         score: PropTypes.string,
-    }),
+    }).isRequired,
     visitor: PropTypes.shape({
         abbreviation: PropTypes.string.isRequired,
         city: PropTypes.string.isRequired,
         score: PropTypes.string,
-    }),
+    }).isRequired,
     periodTime: PropTypes.shape({
         periodStatus: PropTypes.string.isRequired,
         gameClock: PropTypes.string.isRequired,
         gameStatus: PropTypes.string.isRequired,
-    }),
+    }).isRequired,
     playoffs: PropTypes.shape({
         home_wins: PropTypes.string,
         visitor_wins: PropTypes.string,

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -22,7 +22,7 @@ const TeamScore = styled.div`
         if (props.dark && props.winning) return Theme.dark.winning
         if (props.winning) return Theme.light.winning
     }};
-    opacity: ${(props) => (props.winning ? '' : '0.5')};
+    opacity: ${(props) => (props.losing ? '0.5' : '')};
 `
 
 const renderScores = (dark, spoiler, gameStatus, home, visitor) => {
@@ -38,9 +38,21 @@ const renderScores = (dark, spoiler, gameStatus, home, visitor) => {
         }
         return (
             <Row>
-                <TeamScore dark={dark} winning={+visitor.score > +home.score ? 1 : 0}> {visitor.score} </TeamScore>
-                -
-                <TeamScore dark={dark} winning={+visitor.score < +home.score ? 1 : 0}> {home.score} </TeamScore>
+                <TeamScore
+                    dark={dark}
+                    winning={+visitor.score > +home.score}
+                    losing={+visitor.score < +home.score}
+                >
+                    {visitor.score}
+                </TeamScore>
+            -
+                <TeamScore
+                    dark={dark}
+                    winning={+visitor.score < +home.score}
+                    losing={+visitor.score > +home.score}
+                >
+                    {home.score}
+                </TeamScore>
             </Row>
         )
     }

--- a/src/app/components/Scores/AdvancedTeamStats.jsx
+++ b/src/app/components/Scores/AdvancedTeamStats.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { StickyTable, Row } from 'react-sticky-table'
-import { Cell, HeaderCell as FormatHeaderCell, RowHeaderCell } from '../../utils/format'
+import { Cell, HeaderCell as FormatHeaderCell, RowHeaderCell, getOddRowColor } from '../../utils/format'
+import { SettingsConsumer } from '../Context'
 
 const Wrapper = styled.div`
     width: 100%;
@@ -33,8 +34,8 @@ const renderHeaderRow = () => {
 }
 
 
-const renderTeamRow = (team, name) => (
-    <Row>
+const renderTeamRow = (team, name, isDark, i = 0) => (
+    <Row style={{backgroundColor: getOddRowColor(i, isDark)}}>
         <RowHeaderCell> {name} </RowHeaderCell>
         <Cell>{team.biggestLead || 0}</Cell>
         <Cell>{team.benchPoints || 0}</Cell>
@@ -50,11 +51,15 @@ class TeamStats extends React.PureComponent {
         const { home, hta, visitor, vta, extra } = this.props
         return (
             <Wrapper>
-                <StickyTable stickyHeaderCount={0}>
-                    {renderHeaderRow(0)}
-                    {renderTeamRow(visitor, vta)}
-                    {renderTeamRow(home, hta)}
-                </StickyTable>
+                <SettingsConsumer>
+                    {({state: { dark }}) => (
+                        <StickyTable stickyHeaderCount={0}>
+                            {renderHeaderRow(0)}
+                            {renderTeamRow(visitor, vta, dark)}
+                            {renderTeamRow(home, hta, dark, 1)}
+                        </StickyTable>
+                    )}
+                </SettingsConsumer>
                 <div  style={{marginTop: '15px'}}>
                     <StickyTable>
                         <Row>

--- a/src/app/components/Scores/PlayByPlay.jsx
+++ b/src/app/components/Scores/PlayByPlay.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { StickyTable, Row } from 'react-sticky-table'
-import { Cell, HeaderCell, quarterNames } from '../../utils/format'
+import { SettingsConsumer } from '../Context'
+import { Cell, getOddRowColor, HeaderCell, quarterNames } from '../../utils/format'
 import { RowCSS } from '../../styles'
 import { getLogoColorByName } from '../../utils/teams'
 
@@ -40,7 +41,7 @@ const renderHeaderRow = () => (
     </Row>
 )
 
-const renderPBPRow = (plays, period) => {
+const renderPBPRow = (plays, period, isDark) => {
     if (plays && plays.length === 0) {
         return <Row> <Cell> No Data Avaiable </Cell> </Row>
     }
@@ -67,7 +68,7 @@ const renderPBPRow = (plays, period) => {
         const description = _description.replace(/\[.*\]/i, '').trim()
 
         return (
-            <Row key={`pbp-${period}-${i}`}>
+            <Row key={`pbp-${period}-${i}`} style={{backgroundColor: getOddRowColor(i, isDark)}}>
                 <Cell> {clock} </Cell>
                 {LOGO}
                 {SCORE}
@@ -125,10 +126,14 @@ class PlayByPlay extends React.PureComponent {
                     <Hint style={{backgroundColor: '#1b5e20'}}> Lead Changes </Hint>
                     <Hint style={{backgroundColor: '#7c4dff'}}> Tied </Hint>
                 </Title>
-                <StickyTable stickyHeaderCount={0} stickyColumnCount={0}>
-                    {renderHeaderRow()}
-                    {renderPBPRow(play, currentQuarter)}
-                </StickyTable>
+                <SettingsConsumer>
+                    {({state: {dark}}) => (
+                        <StickyTable stickyHeaderCount={0} stickyColumnCount={0}>
+                            {renderHeaderRow()}
+                            {renderPBPRow(play, currentQuarter, dark)}
+                        </StickyTable>
+                    )}
+                </SettingsConsumer>
             </Wrapper>
         )
     }

--- a/src/app/components/Scores/PlayerStats.jsx
+++ b/src/app/components/Scores/PlayerStats.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { StickyTable } from 'react-sticky-table'
 import {
     Cell,
+    getOddRowColor,
     HeaderCell,
     RowHeaderCell,
     Sup,
@@ -73,7 +74,7 @@ const renderHeaderRow = (name) => {
  * @param {*} player
  * @param {*} isLive
  */
-const renderPlayerRow = (player, isLive, isDark, hideZeroRow) => {
+const renderPlayerRow = (player, isLive, i, isDark, hideZeroRow) => {
     if (hideZeroRow && player.minutes == '0' && player.seconds == '0') {
         return
     }
@@ -110,13 +111,13 @@ const renderPlayerRow = (player, isLive, isDark, hideZeroRow) => {
     return (
         <RowWrapper
             key={name}
-            style={{ backgroundColor: rowBGColor(doubles, isDark) }}
+            style={{ backgroundColor: doubles ? rowBGColor(doubles, isDark) : getOddRowColor(i, isDark) }}
             title={doubles && getDoublesText(doubles)}
         >
             <PlayerName>
                 {name}
                 {starting_position && <Sup>{starting_position}</Sup>}
-                {isLive && +on_court && <OnCourt src="assets/png/icon-color-128.png" />}
+                {isLive && on_court === 1 && <OnCourt src="assets/png/icon-color-128.png" />}
             </PlayerName>
             <Cell>{formatMinutes(player)}</Cell>
             <StatsCell dark={isDark ? 1 : 0} winning={+points >= 10 ? 1 : 0}>{points}</StatsCell>
@@ -192,9 +193,9 @@ class PlayerStats extends React.PureComponent {
                     {({ state: { dark, hideZeroRow } }) => (
                         <StickyTable stickyHeaderCount={0}>
                             {renderHeaderRow(vta)}
-                            {vps.map(player => (renderPlayerRow(player, isLive, dark, hideZeroRow)))}
+                            {vps.map((player, i) => (renderPlayerRow(player, isLive, i, dark, hideZeroRow)))}
                             {renderHeaderRow(hta)}
-                            {hps.map(player => (renderPlayerRow(player, isLive, dark, hideZeroRow)))}
+                            {hps.map((player, i) => (renderPlayerRow(player, isLive, i, dark, hideZeroRow)))}
                         </StickyTable>
                     )}
                 </SettingsConsumer>

--- a/src/app/components/Scores/Summary.jsx
+++ b/src/app/components/Scores/Summary.jsx
@@ -2,15 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { StickyTable, Row } from 'react-sticky-table'
-import { Cell, HeaderCell, RowHeaderCell } from '../../utils/format'
+import { Cell, getOddRowColor, HeaderCell, RowHeaderCell } from '../../utils/format'
 import { SettingsConsumer } from '../Context'
 
 const Wrapper = styled.div`
     width: 100%;
 `
 
-const renderTeamRow = (team, otherTeam, isDark) => (
-    <Row>
+const renderTeamRow = (team, otherTeam, isDark, i = 0) => (
+    <Row style={{backgroundColor: getOddRowColor(i, isDark)}}>
         <RowHeaderCell>{team.abbreviation}</RowHeaderCell>
         {team.linescores && team.linescores.period.map((period, index) => (
             <Cell
@@ -42,7 +42,7 @@ class Summary extends React.PureComponent {
                                 <HeaderCell> Final </HeaderCell>
                             </Row>
                             {renderTeamRow(visitor, home, dark)}
-                            {renderTeamRow(home, visitor, dark)}
+                            {renderTeamRow(home, visitor, dark, 1)}
                         </StickyTable>
                     )}
                 </SettingsConsumer>

--- a/src/app/components/Scores/TeamStats.jsx
+++ b/src/app/components/Scores/TeamStats.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { StickyTable, Row } from 'react-sticky-table'
-import { Cell, HeaderCell, RowHeaderCell } from '../../utils/format'
+import { Cell, getOddRowColor, HeaderCell, RowHeaderCell } from '../../utils/format'
+import { SettingsConsumer } from '../Context'
 
 const Wrapper = styled.div`
     width: 100%;
@@ -33,8 +34,8 @@ const renderHeaderRow = () => {
     )
 }
 
-const renderTeamRow = (team, name) => (
-    <Row>
+const renderTeamRow = (team, name, isDark, i = 0) => (
+    <Row style={{backgroundColor: getOddRowColor(i, isDark)}}>
         <RowHeaderCell> {name} </RowHeaderCell>
         <Cell>{`${team.field_goals_made}-${team.field_goals_attempted}`}</Cell>
         <Cell>{team.field_goals_percentage}%</Cell>
@@ -56,11 +57,15 @@ class TeamStats extends React.PureComponent {
         const { hts, vts, hta, vta } = this.props
         return (
             <Wrapper>
-                <StickyTable stickyHeaderCount={0}>
-                    {renderHeaderRow(0)}
-                    {renderTeamRow(vts, vta)}
-                    {renderTeamRow(hts, hta)}
-                </StickyTable>
+                <SettingsConsumer>
+                    {({state: { dark }})=> (
+                        <StickyTable stickyHeaderCount={0}>
+                            {renderHeaderRow(0)}
+                            {renderTeamRow(vts, vta, dark)}
+                            {renderTeamRow(hts, hta, dark, 1)}
+                        </StickyTable>
+                    )}
+                </SettingsConsumer>
             </Wrapper>
         )
     }

--- a/src/app/containers/BoxScores/convert.js
+++ b/src/app/containers/BoxScores/convert.js
@@ -1,6 +1,9 @@
 import {toPercentage, quarterNames} from '../../utils/format'
 
 const getStats = (old, points) => {
+    if (!old) {
+        return {}
+    }
     return {
         assists: old.ast,
         blocks: old.blk,
@@ -25,7 +28,7 @@ const getStats = (old, points) => {
     }
 }
 
-const getPlayers = (players) => {
+const getPlayers = (players = []) => {
     return players.map(player => ({
         assists: player.ast,
         blocks: player.blk,
@@ -78,11 +81,13 @@ const getLinescores = (stats, p) => {
 
 export default (old) => {
     const {
-        offs,
+        cl,
         hls,
-        vls,
+        offs,
         p,
         st,
+        stt,
+        vls,
     } = old
     let officials = []
     if (offs && offs.off) {
@@ -95,9 +100,15 @@ export default (old) => {
 
     return {
         officials,
-        status: st,
+        periodTime: {
+            periodValue: `${p}`,
+            periodStatus: `${stt}`,
+            gameClock: cl,
+            gameStatus: `${st}`,
+        },
         home: {
             abbreviation: hls.ta,
+            city: hls.tc,
             linescores: { period: getLinescores(hls, p) },
             nickname: hls.tn,
             players: { player: getPlayers(hls.pstsg) },
@@ -106,6 +117,7 @@ export default (old) => {
         },
         visitor: {
             abbreviation: vls.ta,
+            city: vls.tc,
             linescores: { period: getLinescores(vls, p) },
             nickname: vls.tn,
             players: { player: getPlayers(vls.pstsg) },

--- a/src/app/containers/BoxScores/reducers.js
+++ b/src/app/containers/BoxScores/reducers.js
@@ -12,14 +12,17 @@ const initState = {
     teamStats: {},
 }
 
-const sanitizeBS = ({ home, visitor, officials, status }) => ({
+const sanitizeBS = ({ home, visitor, officials, periodTime }) => ({
     home,
     visitor,
-    status,
+    periodTime,
     officials: officials || [],
 })
 
 const teamStatsConverter = (data) => {
+    if (!data) {
+        return {}
+    }
     return {
         benchPoints: data.bpts,
         biggestLead: data.ble,
@@ -55,7 +58,7 @@ const pbpDecorater = (pbp) => {
     let prev = null
     return {
         ...pbp,
-        play: pbp.play.map(play => {
+        play: (pbp.play || []).map(play => {
             const curr = +play.home_score - +play.visitor_score
             let next
             if (curr !== 0) {

--- a/src/app/containers/Options/Options.jsx
+++ b/src/app/containers/Options/Options.jsx
@@ -110,7 +110,7 @@ class Options extends React.Component {
     render() {
         return (
             <Layout>
-                <Layout.Header>{<Header index={1}/>}</Layout.Header>
+                <Layout.Header>{<Header index={3}/>}</Layout.Header>
                 <Layout.Content>
                     <SettingsConsumer>
                         {context => this.renderContent(context)}

--- a/src/app/containers/Playoff/Playoff.jsx
+++ b/src/app/containers/Playoff/Playoff.jsx
@@ -83,7 +83,7 @@ class Playoff extends React.Component {
     render() {
         return (
             <Layout>
-                <Layout.Header>{<Header index={3}/>}</Layout.Header>
+                <Layout.Header>{<Header index={2}/>}</Layout.Header>
                 <Layout.Content>{this.renderContent()}</Layout.Content>
             </Layout>
         )

--- a/src/app/containers/Popup/PopUp.jsx
+++ b/src/app/containers/Popup/PopUp.jsx
@@ -16,7 +16,7 @@ import browser from '../../utils/browser'
 const Wrapper = styled(Column)`
     padding: 10px;
     width: 100%;
-    min-width: 330px;
+    min-width: 360px;
 `
 
 class PopUp extends React.Component {
@@ -62,7 +62,7 @@ class PopUp extends React.Component {
         const { live } = this.props
         return (
             <Wrapper>
-                <DatePicker hide={true} onChange={this.selectDate.bind(this)}/>
+                <DatePicker hide={this.state.isPopup} onChange={this.selectDate.bind(this)}/>
                 <Links />
                 <CardList selected={'0'} isLoading={live.isLoading} games={live.games} onClick={this.selectGame.bind(this)}/>
             </Wrapper>

--- a/src/app/containers/Popup/reducers.js
+++ b/src/app/containers/Popup/reducers.js
@@ -4,6 +4,7 @@ import moment from 'moment-timezone'
 const initState = {
     isLoading: false,
     games: [],
+    lastUpdate: new Date(0),
 }
 
 const getBroadcaster = (casters) => {
@@ -55,12 +56,14 @@ export default (state = initState, action) => {
                 ...state,
                 games: sanitizeGames(action.payload),
                 isLoading: false,
+                lastUpdate: new Date(),
             }
         case types.REQUEST_ERROR:
             return {
                 ...state,
                 games: [],
                 isLoading: false,
+                lastUpdate: new Date(0),
             }
         default:
             return state

--- a/src/app/containers/Standings/Standings.jsx
+++ b/src/app/containers/Standings/Standings.jsx
@@ -95,7 +95,7 @@ class Standings extends React.Component {
                 <Cell>{team.win}</Cell>
                 <Cell>{team.loss}</Cell>
                 <Cell>{(Math.round(team.percentage * 100))}%</Cell>
-                <NonMainCell>{team.gamesBehind}</NonMainCell>
+                <Cell>{team.gamesBehind}</Cell>
                 <NonMainCell>{team.homeRecord}</NonMainCell>
                 <NonMainCell>{team.awayRecord}</NonMainCell>
                 <NonMainCell>{team.lastTenRecord}</NonMainCell>
@@ -149,7 +149,7 @@ class Standings extends React.Component {
     render() {
         return (
             <Layout>
-                <Layout.Header>{<Header index={2}/>}</Layout.Header>
+                <Layout.Header>{<Header index={1}/>}</Layout.Header>
                 <Layout.Content>
                     {this.renderContent()}
                 </Layout.Content>

--- a/src/app/containers/Standings/Standings.jsx
+++ b/src/app/containers/Standings/Standings.jsx
@@ -63,7 +63,6 @@ class Standings extends React.Component {
 
     renderHeader(conf) {
         const headers = [
-            'GB',
             'Home Record',
             'Road Record',
             'L10 Streak',
@@ -80,6 +79,7 @@ class Standings extends React.Component {
                 <HeaderCell>Win</HeaderCell>
                 <HeaderCell>Loss</HeaderCell>
                 <HeaderCell>Win %</HeaderCell>
+                <HeaderCell>GB</HeaderCell>
                 {headers.map(element => (
                     <NonMainHeaderCell key={`stats-${element}-${conf}`}>{element}</NonMainHeaderCell>
                 ))}

--- a/src/app/reducers.js
+++ b/src/app/reducers.js
@@ -13,7 +13,6 @@ export const initialState = {}
 // combined reducer
 export default combineReducers({
     routing,
-    // app: appReducer,
     live: liveReducer,
     bs: boxScoresReducer,
     date: dateReducer,

--- a/src/app/utils/alarms.js
+++ b/src/app/utils/alarms.js
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone'
 import browser from './browser'
-import {store} from '../store'
+import { store } from '../store'
 import { fetchLiveGameBoxIfNeeded } from '../containers/BoxScores/actions'
 import { fetchGamesIfNeeded } from '../containers/Popup/actions'
 import { DATE_FORMAT } from '../utils/format'
@@ -12,11 +12,21 @@ browser.alarms.create('minute', {
 
 browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === 'minute') {
-        const { bs, date: {date}} = store.getState()
+        const { bs, date: {date}, live: {games}} = store.getState()
         const dateStr = moment(date).format(DATE_FORMAT)
         fetchGamesIfNeeded(dateStr)(store.dispatch, store.getState)
         if (bs && bs.gid !== '') {
             fetchLiveGameBoxIfNeeded(dateStr, bs.gid)(store.dispatch, store.getState)
+        }
+
+        const hasLiveGame = games.find(game =>
+            game.period_time && game.period_time.game_status === '2'
+        )
+        if (hasLiveGame) {
+            browser.setBadgeText({ text: 'live' })
+            browser.setBadgeBackgroundColor({ color: '#FC0D1B' })
+        } else {
+            browser.setBadgeText({ text: '' })
         }
     }
 })

--- a/src/app/utils/alarms.js
+++ b/src/app/utils/alarms.js
@@ -14,9 +14,9 @@ browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === 'minute') {
         const { bs, date: {date}} = store.getState()
         const dateStr = moment(date).format(DATE_FORMAT)
-        fetchGamesIfNeeded(dateStr)(store.dispatch)
+        fetchGamesIfNeeded(dateStr)(store.dispatch, store.getState)
         if (bs && bs.gid !== '') {
-            fetchLiveGameBoxIfNeeded(dateStr, bs.gid)(store.dispatch)
+            fetchLiveGameBoxIfNeeded(dateStr, bs.gid)(store.dispatch, store.getState)
         }
     }
 })

--- a/src/app/utils/browser.js
+++ b/src/app/utils/browser.js
@@ -72,7 +72,7 @@ if (typeof browser !== 'undefined') {
             browser.tabs.create(options)
         },
         getCurrent: (callback) => {
-            browser.tabs.getCurrent().then(() => callback())
+            browser.tabs.getCurrent().then((tab) => callback(tab))
         },
     }
 
@@ -159,7 +159,7 @@ if (typeof browser !== 'undefined') {
             chrome.tabs.create(options)
         },
         getCurrent: (callback) => {
-            chrome.tabs.getCurrent(() => callback())
+            chrome.tabs.getCurrent((tab) => callback(tab))
         },
     }
 

--- a/src/app/utils/format.js
+++ b/src/app/utils/format.js
@@ -182,10 +182,20 @@ export const toPercentage = (decimal) => {
  * determine who is winning
  */
 export const isWinning = (self, other) => {
-    if (self === '' && other === '') {
+    if ((!self && !other) || (self === other)) {
         return true
     } else {
         return +self > +other
+    }
+}
+
+/**
+ * get background color for odd number rows
+ */
+export const getOddRowColor = (i, isDark) => {
+    if (i % 2 === 1) {
+        if (isDark) return 'hsl(0, 0%, 25%)'
+        else return 'hsl(0, 0%, 95%)'
     }
 }
 


### PR DESCRIPTION
- Fix card list will not reload due to being the same day
  - Add smart detect in fetch.
  - Add is fetching in background check so it won't show loading spinner
- Fix on court status missing
- Fix team logo is faded when the match is tied
- Fix reducer throws error when expected field is missing

- Add background color to odd number rows
- Add clock + status on to box score
  - Use same format function for both of them
- Change the order of box score section, ie. move player stats before team stats
- Change the order of tab item, ie. options becomes the last
- Add games behind to the main cell, ie. it shows up in handheld device