### PR TITLE
feat: add a reveal button when no spoiler is turned on

### DIFF
--- a/src/app/components/Card.jsx
+++ b/src/app/components/Card.jsx
@@ -31,7 +31,6 @@ const Wrapper = styled.div`
   border: ${(props) =>
     props.selected ? '2px solid rgb(30, 90, 250)' : '2px solid transparent'};
 
-
   &::before {
     ${(props) =>
       props.fav &&
@@ -59,8 +58,20 @@ const MatchCard = ({
   showBroadcast,
   ...rest
 }) => {
-  const { abbreviation: hta, nickname: htn, score: hs, wins: hw, losses: hl } = home
-  const { abbreviation: vta, nickname: vtn, score: vs, wins: vw, losses: vl } = visitor
+  const {
+    abbreviation: hta,
+    nickname: htn,
+    score: hs,
+    wins: hw,
+    losses: hl,
+  } = home
+  const {
+    abbreviation: vta,
+    nickname: vtn,
+    score: vs,
+    wins: vw,
+    losses: vl,
+  } = visitor
 
   return (
     <ThemeConsumer>
@@ -74,7 +85,13 @@ const MatchCard = ({
               selected={selected}
               fav={teams.includes(vta) || teams.includes(hta)}
             >
-              <TeamInfo ta={vta} tn={vtn} winning={isWinning(vs, hs)} wins={vw} losses={vl} />
+              <TeamInfo
+                ta={vta}
+                tn={vtn}
+                winning={isWinning(vs, hs)}
+                wins={vw}
+                losses={vl}
+              />
               <MatchInfo
                 id={id}
                 home={home}
@@ -82,7 +99,13 @@ const MatchCard = ({
                 broadcasters={showBroadcast ? broadcasters : undefined}
                 {...rest}
               />
-              <TeamInfo ta={hta} tn={htn} winning={isWinning(hs, vs)} wins={hw} losses={hl} />
+              <TeamInfo
+                ta={hta}
+                tn={htn}
+                winning={isWinning(hs, vs)}
+                wins={hw}
+                losses={hl}
+              />
             </Wrapper>
           )}
         </SidebarConsumer>

--- a/src/app/components/Card.jsx
+++ b/src/app/components/Card.jsx
@@ -11,13 +11,11 @@ import { SidebarConsumer, ThemeConsumer } from '../components/Context'
 const Wrapper = styled.div`
   ${RowCSS}
   ${JustifyCenter}
-    ${AlignCenter}
-    ${Shadow}
-    position: relative;
+  ${AlignCenter}
+  ${Shadow}
+  position: relative;
   min-height: 90px;
-  width: 100%;
   padding: 5px;
-  margin-bottom: 15px;
   font-size: calc(17px + 0.1vw);
   background-color: ${(props) =>
     props.dark ? Theme.dark.blockBackground : '#f9f9f9'};
@@ -33,9 +31,6 @@ const Wrapper = styled.div`
   border: ${(props) =>
     props.selected ? '2px solid rgb(30, 90, 250)' : '2px solid transparent'};
 
-  &:last-child {
-    margin-bottom: 0px;
-  }
 
   &::before {
     ${(props) =>

--- a/src/app/components/CardList.jsx
+++ b/src/app/components/CardList.jsx
@@ -7,13 +7,14 @@ import { SidebarConsumer } from './Context'
 import browser from '../utils/browser'
 
 const Wrapper = styled.div`
-  display: block;
-  width: 100%;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  display: grid;
+  gap: 0.75rem;
 
   ${mediaQuery`
         min-height: 100px;
         padding: 0 5px 10px 5px;
-        ${(props) => props.isPopup && 'max-height: 350px;'}
+        ${(props) => props.isPopup && 'max-height: 370px;'}
         ${(props) => props.isSidebar && 'max-height: 250px;'}
         overflow-y: scroll;
     `}

--- a/src/app/components/CardList.jsx
+++ b/src/app/components/CardList.jsx
@@ -7,7 +7,7 @@ import { SidebarConsumer } from './Context'
 import browser from '../utils/browser'
 
 const Wrapper = styled.div`
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
   display: grid;
   gap: 0.75rem;
 

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Row, Theme } from '../styles'
@@ -11,6 +11,21 @@ const Wrapper = styled.div`
 
   & > * {
     margin-top: 5px;
+  }
+`
+const Button = styled.button`
+  border-radius: 5px;
+  box-sizing: border-box;
+  background-color: ${(props) => (props.dark ? 'black' : 'transparent')};
+  border: 1px solid rgb(168, 199, 250);
+  color: ${(props) => (props.dark ? 'rgb(168, 199, 250)' : 'rgb(11, 87, 208)')};
+  padding: 1px 8px;
+  outline-width: 0px;
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${(props) =>
+      props.dark ? '#38393b' : 'rgb(197, 217, 215)'};
   }
 `
 
@@ -115,7 +130,9 @@ const MatchInfo = ({
   playoffs,
   urls,
   seriesText,
+  showReveal = true,
 }) => {
+  const [reveal, setReveal] = useState(!showReveal)
   let series = ''
   if (playoffs) {
     const { home_wins: homeWins, visitor_wins: visitorWins } = playoffs
@@ -136,12 +153,36 @@ const MatchInfo = ({
         <SettingsConsumer>
           {({ state: { spoiler } }) => (
             <Wrapper>
-              {renderScores(dark, spoiler, gameStatus, home, visitor)}
+              {renderScores(
+                dark,
+                spoiler && !reveal,
+                gameStatus,
+                home,
+                visitor
+              )}
               {renderAt(gameStatus)}
-              <div>
-                {renderStatusAndClock(periodStatus, gameClock, periodValue)}
-              </div>
-              {!spoiler && series && <div>{series}</div>}
+              {(!spoiler || reveal) && (
+                <div>
+                  {' '}
+                  {renderStatusAndClock(
+                    periodStatus,
+                    gameClock,
+                    periodValue
+                  )}{' '}
+                </div>
+              )}
+              {(!spoiler || reveal) && series && <div>{series}</div>}
+              {spoiler && !reveal && showReveal && (
+                <Button
+                  dark={dark}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setReveal(!reveal)
+                  }}
+                >
+                  Reveal
+                </Button>
+              )}
               {broadcasters != null &&
                 renderBroadcasters(broadcasters, gameStatus)}
               {renderHighlight(id, urls, dark)}
@@ -180,6 +221,8 @@ MatchInfo.propTypes = {
     visitor_wins: PropTypes.string,
   }),
   urls: PropTypes.object,
+  // whether or not to have the reveal button. In box score detail page, do not show it.
+  showReveal: PropTypes.bool,
 }
 
 MatchInfo.defaultProps = {

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -158,8 +158,8 @@ const MatchInfo = ({
                 visitor
               )}
               {renderAt(gameStatus)}
-              {/* no spoiler is on && (either game has not start OR it has starts and the reveal has been clicked) */}
-              {spoiler && (gameStatus == 1 || (gameStatus != 1 && reveal)) && (
+              {/* either game has not start OR it has starts and the reveal has been clicked */}
+              {(gameStatus == 1 || (gameStatus != 1 && (reveal || !spoiler))) && (
                 <div>
                   {renderStatusAndClock(
                     periodStatus,

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -46,11 +46,7 @@ const SubText = styled.div`
 const renderScores = (dark, spoiler, gameStatus, home, visitor) => {
   if (gameStatus !== '1') {
     if (spoiler) {
-      return (
-        <Row>
-          <TeamScore> --- </TeamScore>-<TeamScore> --- </TeamScore>
-        </Row>
-      )
+      return renderAt('1')
     }
     return (
       <Row>
@@ -161,18 +157,20 @@ const MatchInfo = ({
                 visitor
               )}
               {renderAt(gameStatus)}
-              {(!spoiler || reveal) && (
+              {/* no spoiler is on && (either game has not start OR it has starts and the reveal has been clicked) */}
+              {spoiler && (gameStatus == 1 || (gameStatus != 1 && reveal)) && (
                 <div>
-                  {' '}
                   {renderStatusAndClock(
                     periodStatus,
                     gameClock,
                     periodValue
-                  )}{' '}
+                  )}
                 </div>
               )}
+              {/* no spoiler is off || revel has been clicked */}
               {(!spoiler || reveal) && series && <div>{series}</div>}
-              {spoiler && !reveal && showReveal && (
+              {/* in cards && game has started && no spoiler is on && revel has not been clicked */}
+              {showReveal && gameStatus != 1 && spoiler && !reveal && (
                 <Button
                   dark={dark}
                   onClick={(e) => {
@@ -183,8 +181,7 @@ const MatchInfo = ({
                   Reveal
                 </Button>
               )}
-              {broadcasters != null &&
-                renderBroadcasters(broadcasters, gameStatus)}
+              {broadcasters != null && renderBroadcasters(broadcasters, gameStatus)}
               {renderHighlight(id, urls, dark)}
             </Wrapper>
           )}

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -46,6 +46,7 @@ const SubText = styled.div`
 const renderScores = (dark, spoiler, gameStatus, home, visitor) => {
   if (gameStatus !== '1') {
     if (spoiler) {
+      // mock the game has not start symbol
       return renderAt('1')
     }
     return (

--- a/src/app/components/TeamInfo.jsx
+++ b/src/app/components/TeamInfo.jsx
@@ -50,7 +50,9 @@ const TeamInfo = ({ ta, tn, winning, large, wins, losses }) => {
           </TeamLogo>
           <TeamName winning={spoiler ? true : winning}>{tn}</TeamName>
           {wins && losses && (
-            <TeamRecord>{wins}-{losses}</TeamRecord>
+            <TeamRecord>
+              {wins}-{losses}
+            </TeamRecord>
           )}
         </TeamInfoWrapper>
       )}

--- a/src/app/containers/BoxScores/styles.js
+++ b/src/app/containers/BoxScores/styles.js
@@ -4,7 +4,7 @@ import { mediaQuery } from '../../styles'
 export const Wrapper = styled.div`
   display: grid;
   grid-template-areas: 'sidebar content';
-  grid-template-columns: minmax(350px, 27%) 1fr;
+  grid-template-columns: minmax(400px, 27%) 1fr;
   grid-gap: 1em 1em;
   padding: 10px 0;
 

--- a/src/app/containers/BoxScores/styles.js
+++ b/src/app/containers/BoxScores/styles.js
@@ -4,7 +4,7 @@ import { mediaQuery } from '../../styles'
 export const Wrapper = styled.div`
   display: grid;
   grid-template-areas: 'sidebar content';
-  grid-template-columns: minmax(27%, 300px) 1fr;
+  grid-template-columns: minmax(350px, 27%) 1fr;
   grid-gap: 1em 1em;
   padding: 10px 0;
 

--- a/src/app/containers/BoxScoresDetails/BoxScoresDetails.jsx
+++ b/src/app/containers/BoxScoresDetails/BoxScoresDetails.jsx
@@ -73,17 +73,15 @@ const BoxScoresDetails = ({
           if (spoiler && !reveal) {
             return (
               <Overlay text="Turn off no spoiler">
-                {spoiler && !reveal && (
-                  <Button
-                    dark={dark}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setReveal(!reveal)
-                    }}
-                  >
-                    Reveal
-                  </Button>
-                )}
+                <Button
+                  dark={dark}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setReveal(!reveal)
+                  }}
+                >
+                  Reveal
+                </Button>
                 <NoSpoilerCheckbox />
               </Overlay>
             )

--- a/src/app/containers/BoxScoresDetails/BoxScoresDetails.jsx
+++ b/src/app/containers/BoxScoresDetails/BoxScoresDetails.jsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router-dom'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import format from 'date-fns/format'
 import Overlay from '../../components/Overlay'
@@ -24,6 +25,23 @@ import {
 } from './helpers'
 import { DATE_FORMAT } from '../../utils/constant'
 
+const Button = styled.button`
+  border-radius: 5px;
+  box-sizing: border-box;
+  background-color: ${(props) => (props.dark ? 'black' : 'transparent')};
+  border: 1px solid rgb(168, 199, 250);
+  color: ${(props) => (props.dark ? 'rgb(168, 199, 250)' : 'rgb(11, 87, 208)')};
+  padding: 1px 8px;
+  margin-bottom: 16px;
+  outline-width: 0px;
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${(props) =>
+      props.dark ? '#38393b' : 'rgb(197, 217, 215)'};
+  }
+`
+
 const BoxScoresDetails = ({
   bs: { bsData, pbpData, teamStats, isLoading },
   id,
@@ -44,6 +62,7 @@ const BoxScoresDetails = ({
     (spoiler, dark) => {
       // Route expects a function for component prop
       const contentComponent = () => {
+        const [reveal, setReveal] = useState(false)
         if (
           !bsData ||
           Object.keys(bsData).length === 0 ||
@@ -51,9 +70,20 @@ const BoxScoresDetails = ({
         ) {
           return <Overlay text={'Game has not started'} />
         } else {
-          if (spoiler) {
+          if (spoiler && !reveal) {
             return (
               <Overlay text="Turn off no spoiler">
+                {spoiler && !reveal && (
+                  <Button
+                    dark={dark}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setReveal(!reveal)
+                    }}
+                  >
+                    Reveal
+                  </Button>
+                )}
                 <NoSpoilerCheckbox />
               </Overlay>
             )

--- a/src/app/containers/BoxScoresDetails/helpers.js
+++ b/src/app/containers/BoxScoresDetails/helpers.js
@@ -39,6 +39,7 @@ export const renderTitle = (bsData) => {
           score: `${visitor.score}`,
         }}
         periodTime={periodTime}
+        showReveal={false}
       />
       <TeamInfo ta={hta} tn={htn} winning={isWinning(hs, vs)} large={true} />
     </Title>

--- a/src/app/containers/Popup/PopUp.jsx
+++ b/src/app/containers/Popup/PopUp.jsx
@@ -21,7 +21,7 @@ import browser from '../../utils/browser'
 const Wrapper = styled(Column)`
   padding: 10px;
   width: 100%;
-  min-width: 400px;
+  min-width: 450px;
 `
 
 const PopUp = ({

--- a/src/app/containers/Popup/PopUp.jsx
+++ b/src/app/containers/Popup/PopUp.jsx
@@ -21,7 +21,7 @@ import browser from '../../utils/browser'
 const Wrapper = styled(Column)`
   padding: 10px;
   width: 100%;
-  min-width: 370px;
+  min-width: 400px;
 `
 
 const PopUp = ({

--- a/src/app/utils/convert.js
+++ b/src/app/utils/convert.js
@@ -284,7 +284,7 @@ export const convertDaily3 = (game) => {
       nickname: getNickNamesByTriCode(h.teamTricode),
       score: `${h.score}`,
       wins: h?.wins,
-      losses: h?.losses
+      losses: h?.losses,
     },
     visitor: {
       abbreviation: v.teamTricode,
@@ -293,7 +293,7 @@ export const convertDaily3 = (game) => {
       nickname: getNickNamesByTriCode(v.teamTricode),
       score: `${v.score}`,
       wins: v?.wins,
-      losses: v?.losses
+      losses: v?.losses,
     },
     periodTime: {
       periodStatus: formatGameStatus(),


### PR DESCRIPTION
What
- Increase card width size to 400px
- Move `CardList` to a grid system, which will wrap on horizontal if there is space
- Add a `Reveal` button for temporary turning off no spoiler
- Hide `game` status when no spoiler is on