### PR TITLE
feat: update styles logos & infos

### DIFF
--- a/src/app/components/Card.jsx
+++ b/src/app/components/Card.jsx
@@ -64,6 +64,7 @@ const MatchCard = ({
     score: hs,
     wins: hw,
     losses: hl,
+    id: hid,
   } = home
   const {
     abbreviation: vta,
@@ -71,6 +72,7 @@ const MatchCard = ({
     score: vs,
     wins: vw,
     losses: vl,
+    id: vid,
   } = visitor
   const [reveal, setReveal] = React.useState(false)
 
@@ -87,6 +89,7 @@ const MatchCard = ({
               fav={teams.includes(vta) || teams.includes(hta)}
             >
               <TeamInfo
+                tid={`${vid}`}
                 ta={vta}
                 tn={vtn}
                 winning={isWinning(vs, hs)}
@@ -104,6 +107,7 @@ const MatchCard = ({
                 {...rest}
               />
               <TeamInfo
+                tid={`${hid}`}
                 ta={hta}
                 tn={htn}
                 winning={isWinning(hs, vs)}

--- a/src/app/components/Layout.jsx
+++ b/src/app/components/Layout.jsx
@@ -17,8 +17,8 @@ const HeaderWrapper = styled.div`
 
 const ContentWrapper = styled.div`
   grid-area: content;
-  overflow-y: scroll !important;
   padding: 0 10px;
+  margin: 0 5%;
 `
 
 const Header = ({ children }) => {

--- a/src/app/components/PlayoffColumn.jsx
+++ b/src/app/components/PlayoffColumn.jsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { getTeamNameById, getLogoColorById } from '../utils/teams'
+import {
+  getTeamNameById,
+  getLogoColorById,
+  getNickNamesByTriCode,
+  getAbbreviationById,
+} from '../utils/teams'
 import { mediaQuery } from '../styles'
+import TeamLogo from './TeamLogo'
 
 const StyledSerieColumn = styled.div`
   width: 15%;
@@ -51,10 +57,13 @@ const StyledSeries = styled.div`
 
 const SerieTeamRow = ({ teamId, seedNum, wins, isWinning }) => (
   <StyledSerieTeamRow winning={isWinning} color={getLogoColorById(teamId)}>
-    <div>
-      {getTeamNameById(teamId)}
-      {seedNum ? `(${seedNum})` : ''}
-    </div>
+    {teamId && (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
+        <TeamLogo tn={teamId} ta={getAbbreviationById(teamId)} />
+        <span>{getNickNamesByTriCode(getTeamNameById(teamId))}</span>
+        {seedNum ? `(${seedNum})` : ''}
+      </div>
+    )}
     <div>{wins}</div>
   </StyledSerieTeamRow>
 )

--- a/src/app/components/TeamInfo.jsx
+++ b/src/app/components/TeamInfo.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { getLogoColorByName, TEAM_ID } from '../utils/teams'
 import { SettingsConsumer } from './Context'
 import TeamLogo from './TeamLogo'
 

--- a/src/app/components/TeamInfo.jsx
+++ b/src/app/components/TeamInfo.jsx
@@ -1,25 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { getLogoColorByName } from '../utils/teams'
+import { getLogoColorByName, TEAM_ID } from '../utils/teams'
 import { SettingsConsumer } from './Context'
-
-export const TeamLogo = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  min-width: ${(props) => (props.large ? '65px' : '45px')};
-  min-height: ${(props) => (props.large ? '65px' : '45px')};
-  color: white;
-  border-radius: 50%;
-  font-size: ${(props) => (props.large ? 'calc(20px + 0.3vw)' : 'inherit')};
-
-  background-color: ${(props) =>
-    props.team ? getLogoColorByName(props.team) : '#000000'};
-
-  opacity: ${(props) => (props.winning ? '1' : '0.4')};
-`
+import TeamLogo from './TeamLogo'
 
 const TeamName = styled.div`
   text-align: center;
@@ -40,20 +24,21 @@ const TeamRecord = styled.div`
   opacity: 0.9;
 `
 
-const TeamInfo = ({ ta, tn, winning, large, wins, losses, reveal }) => {
+const TeamInfo = ({ tid, ta, tn, winning, large, wins, losses, reveal }) => {
   return (
     <SettingsConsumer>
       {({ state: { spoiler } }) => (
         <TeamInfoWrapper>
           <TeamLogo
-            winning={spoiler && !reveal ? true : winning}
-            team={ta}
+            spoiler={spoiler}
+            winning={winning}
+            ta={ta}
+            tn={tid}
             large={large}
-          >
-            {ta}
-          </TeamLogo>
+            reveal={reveal}
+          />
           <TeamName winning={spoiler && !reveal ? true : winning}>
-            {tn}
+            {tn || 'TBD'}
           </TeamName>
           {wins != null && losses != null && (
             <TeamRecord>
@@ -67,6 +52,7 @@ const TeamInfo = ({ ta, tn, winning, large, wins, losses, reveal }) => {
 }
 
 TeamInfo.propTypes = {
+  tid: PropTypes.string.isRequired,
   ta: PropTypes.string.isRequired,
   tn: PropTypes.string.isRequired,
   winning: PropTypes.bool,

--- a/src/app/components/TeamLogo.jsx
+++ b/src/app/components/TeamLogo.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { getLogoColorById } from '../utils/teams'
+
+export const Wrapper = styled.div`
+  width: ${(props) => (props.large ? '80px' : '50px')};
+  height: ${(props) => (props.large ? '80px' : '50px')};
+  color: white;
+  border-radius: 50%;
+  font-size: ${(props) => (props.large ? 'calc(20px + 0.3vw)' : 'inherit')};
+  opacity: ${(props) => (props.winning ? '1' : '0.4')};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: ${(props) =>
+    props.team ? getLogoColorById(props.team) : '#000000'};
+`
+// Uncomment for using abbr for logo
+
+const TeamLogo = ({ tn, ta, spoiler, reveal, winning, large }) => {
+  return (
+    <Wrapper
+      winning={spoiler && !reveal ? true : winning}
+      large={large}
+      src={`https://cdn.nba.com/logos/nba/${tn}/primary/L/logo.svg`}
+      alt={ta || 'TBD'}
+      team={tn}
+    >
+      {ta}
+    </Wrapper>
+  )
+}
+
+TeamLogo.propTypes = {
+  ta: PropTypes.string.isRequired,
+  tn: PropTypes.string.isRequired,
+}
+
+TeamLogo.defaultProps = {
+  winning: true,
+  large: false,
+}
+
+export default TeamLogo

--- a/src/app/containers/BoxScoresDetails/helpers.js
+++ b/src/app/containers/BoxScoresDetails/helpers.js
@@ -23,12 +23,13 @@ import TeamLeaderCol from '../../components/Scores/TeamLeaderCol'
 
 export const renderTitle = (bsData, reveal) => {
   const { home, visitor, periodTime } = bsData
-  const { abbreviation: hta, nickname: htn, score: hs } = home
-  const { abbreviation: vta, nickname: vtn, score: vs } = visitor
+  const { abbreviation: hta, nickname: htn, score: hs, id: hid } = home
+  const { abbreviation: vta, nickname: vtn, score: vs, id: vid } = visitor
 
   return (
     <Title justifyCenter={true} alignCenter={true}>
       <TeamInfo
+        tid={`${vid}`}
         ta={vta}
         tn={vtn}
         winning={isWinning(vs, hs)}
@@ -49,6 +50,7 @@ export const renderTitle = (bsData, reveal) => {
         reveal={reveal}
       />
       <TeamInfo
+        tid={`${hid}`}
         ta={hta}
         tn={htn}
         winning={isWinning(hs, vs)}

--- a/src/app/containers/BoxScoresDetails/styles.js
+++ b/src/app/containers/BoxScoresDetails/styles.js
@@ -14,7 +14,6 @@ import {
 export const Content = styled.div`
   ${Shadow}
   grid-area: content;
-  overflow-y: scroll !important;
   padding: 10px;
   border-radius: 5px;
   background-color: ${(props) =>

--- a/src/app/containers/Playoffs/Playoffs.jsx
+++ b/src/app/containers/Playoffs/Playoffs.jsx
@@ -17,7 +17,7 @@ const ColumnWrapper = styled.div`
 const renderContent = ({ isLoading, west, east, final }) => {
   if (isLoading) return <Loader />
   return (
-    <React.Fragment>
+    <div style={{ margin: '0 5%' }}>
       <ColumnWrapper>
         <PlayoffColumn title="RD1" series={west.first} />
         <PlayoffColumn title="RD2" series={west.second} />
@@ -27,7 +27,7 @@ const renderContent = ({ isLoading, west, east, final }) => {
         <PlayoffColumn title="RD2" series={east.second} />
         <PlayoffColumn title="RD1" series={east.first} />
       </ColumnWrapper>
-    </React.Fragment>
+    </div>
   )
 }
 

--- a/src/app/containers/Standings/Standings.jsx
+++ b/src/app/containers/Standings/Standings.jsx
@@ -8,15 +8,16 @@ import Header from '../../components/Header'
 import Loader from '../../components/Loader'
 import * as actions from './actions'
 import { mediaQuery } from '../../styles'
+import TeamLogo from '../../components/TeamLogo'
+import { getAbbreviationById } from '../../utils/teams'
 
 const Cell = styled.td`
   width: 10vw;
-  height: 1.8em !important;
   text-align: center;
   vertical-align: middle;
   ${mediaQuery`width: 20vw;`}
   border: 1px solid #bebebe;
-  padding: 0.5rem 0.75rem;
+  padding: 0.25rem 0.5rem;
 `
 
 const NonMainCell = styled(Cell)`
@@ -85,7 +86,10 @@ const renderConference = (team, i, dark) => {
           {team.playoffCode && `- ${team.playoffCode}`}
         </div>
       </Cell>
-      <Cell>{team.name}</Cell>
+      <Cell style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
+        <TeamLogo tn={`${team.id}`} ta={getAbbreviationById(team.id)} />
+        <span>{team.name}</span>
+      </Cell>
       <Cell>{team.win}</Cell>
       <Cell>{team.loss}</Cell>
       <Cell>{Math.round(team.percentage * 100)}%</Cell>
@@ -126,7 +130,7 @@ const renderContent = (east, west, isLoading) => {
   return (
     <ThemeConsumer>
       {({ state: { dark } }) => (
-        <div style={{ margin: '0 8%' }}>
+        <div style={{ margin: '0 5%' }}>
           <h3>East</h3>
           <table style={{ borderCollapse: 'collapse' }}>
             <tbody>

--- a/src/app/containers/Standings/reducers.js
+++ b/src/app/containers/Standings/reducers.js
@@ -35,6 +35,7 @@ const conferenceExtractorV3 = (teams, isEast) =>
     )
     .map((team) => ({
       name: team[4],
+      id: team[2],
       playoffCode: team[9],
       win: team[13],
       loss: team[14],

--- a/src/app/utils/convert.js
+++ b/src/app/utils/convert.js
@@ -278,19 +278,21 @@ export const convertDaily3 = (game) => {
   return {
     broadcasters: getBroadcasters(watch),
     home: {
+      id: h.teamId,
       abbreviation: h.teamTricode,
       city: h.teamCity,
       linescores: { period: addQuarterNames(h.periods) },
-      nickname: getNickNamesByTriCode(h.teamTricode),
+      nickname: getNickNamesByTriCode(h.teamTricode, h.teamName),
       score: `${h.score}`,
       wins: h?.wins,
       losses: h?.losses,
     },
     visitor: {
+      id: v.teamId,
       abbreviation: v.teamTricode,
       city: v.teamCity,
       linescores: { period: addQuarterNames(v.periods) },
-      nickname: getNickNamesByTriCode(v.teamTricode),
+      nickname: getNickNamesByTriCode(v.teamTricode, v.teamName),
       score: `${v.score}`,
       wins: v?.wins,
       losses: v?.losses,
@@ -493,6 +495,7 @@ export const convertBSProxy = (old) => {
       gameStatus: `${gameStatus}`,
     },
     home: {
+      id: homeTeam.teamId,
       abbreviation: homeTeam.teamTricode,
       city: homeTeam.teamCity,
       linescores: {
@@ -506,6 +509,7 @@ export const convertBSProxy = (old) => {
       stats: getStatsProxy(homeTeam.statistics),
     },
     visitor: {
+      id: awayTeam.teamId,
       abbreviation: awayTeam.teamTricode,
       city: awayTeam.teamCity,
       linescores: {

--- a/src/app/utils/teams.js
+++ b/src/app/utils/teams.js
@@ -184,8 +184,8 @@ export const getLogoColorByName = (name, defaultColor = '#000000') => {
   return LOGO_COLORS[name] || defaultColor
 }
 
-export const getNickNamesByTriCode = (triCode) => {
-  return shortNames[triCode] || triCode
+export const getNickNamesByTriCode = (triCode, defaultValue = undefined) => {
+  return shortNames[triCode] || defaultValue || triCode
 }
 
 export const getLogoColorById = (id) => {
@@ -197,4 +197,20 @@ export const getLogoColorById = (id) => {
     }
   })
   return getLogoColorByName(name)
+}
+
+export const getAbbreviationById = (id) => {
+  let abbr = ''
+  id = typeof id === 'number' ? id.toString() : id
+  Object.keys(TEAM_ID).forEach((key) => {
+    if (TEAM_ID[key] === id) {
+      abbr = key
+    }
+  })
+
+  if (abbr === '') {
+    return 'TBD'
+  }
+
+  return abbr
 }


### PR DESCRIPTION
What 
- separate out `TeamLogo` component
- use the team logo component in standings and playoff
- add `TBD` for team name if no abbreviation is available 

styles
- add margin to layout so it's easier to read
- remove scroll by default, the whole page has the scroll if needed