### PR TITLE
Fix ISO 8601 time duration parsing & misc

### DIFF
--- a/src/app/background.js
+++ b/src/app/background.js
@@ -92,18 +92,17 @@ const liveListener = (initCheck) => {
   }
 
   // cdn
-  fetch('https://api.boxscores.site/v1/scoreboard/today')
+  fetch('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
     .then((res) => res.json())
-    .then(({ games }) => {
+    .then(({ scoreboard: { games } }) => {
       checkLiveGame(games, 3)
       if (!initCheck) {
         fireFavTeamNotificationIfNeeded(sanitizeGames(games, 3))
       }
     })
-    .catch(() => {
-      return fetch(
-        'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json'
-      )
+    .catch((error) => {
+      console.log('something went wrong...', error)
+      return fetch('https://proxy.boxscores.site?apiUrl=cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
         .then((res) => res.json())
         .then(({ scoreboard: { games } }) => {
           checkLiveGame(games, 3)
@@ -111,9 +110,9 @@ const liveListener = (initCheck) => {
             fireFavTeamNotificationIfNeeded(sanitizeGames(games, 3))
           }
         })
-    })
-    .catch((error) => {
-      console.log('something went wrong...', error)
+        .catch((error) => {
+          console.log('something went wrong from proxy...', error)
+        })
     })
 }
 

--- a/src/app/background.js
+++ b/src/app/background.js
@@ -92,7 +92,9 @@ const liveListener = (initCheck) => {
   }
 
   // cdn
-  fetch('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
+  fetch(
+    'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json'
+  )
     .then((res) => res.json())
     .then(({ scoreboard: { games } }) => {
       checkLiveGame(games, 3)
@@ -102,7 +104,9 @@ const liveListener = (initCheck) => {
     })
     .catch((error) => {
       console.log('something went wrong...', error)
-      return fetch('https://proxy.boxscores.site?apiUrl=cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
+      return fetch(
+        'https://proxy.boxscores.site?apiUrl=cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json'
+      )
         .then((res) => res.json())
         .then(({ scoreboard: { games } }) => {
           checkLiveGame(games, 3)

--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Row, Theme } from '../styles'

--- a/src/app/containers/Popup/actions.js
+++ b/src/app/containers/Popup/actions.js
@@ -50,14 +50,17 @@ const fetchRequest3 = async (dateStr) => {
 
   let g = []
   try {
-    const res = await fetch('https://api.boxscores.site/v1/scoreboard/today')
-    const { games } = await res.json()
+    const res = await fetch('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
+    const {
+      scoreboard: { games, gameDate },
+    } = await res.json()
+
+    apiGameDate = gameDate.replaceAll('-', '')
+
     g = games
   } catch (e) {
     try {
-      const res = await fetch(
-        'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json'
-      )
+      const res = await fetch('https://proxy.boxscores.site?apiUrl=cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
       const {
         scoreboard: { games, gameDate },
       } = await res.json()

--- a/src/app/containers/Popup/actions.js
+++ b/src/app/containers/Popup/actions.js
@@ -50,7 +50,9 @@ const fetchRequest3 = async (dateStr) => {
 
   let g = []
   try {
-    const res = await fetch('https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
+    const res = await fetch(
+      'https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json'
+    )
     const {
       scoreboard: { games, gameDate },
     } = await res.json()
@@ -60,7 +62,9 @@ const fetchRequest3 = async (dateStr) => {
     g = games
   } catch (e) {
     try {
-      const res = await fetch('https://proxy.boxscores.site?apiUrl=cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json')
+      const res = await fetch(
+        'https://proxy.boxscores.site?apiUrl=cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json'
+      )
       const {
         scoreboard: { games, gameDate },
       } = await res.json()

--- a/src/app/utils/common.js
+++ b/src/app/utils/common.js
@@ -80,7 +80,7 @@ export const formatClock = (clock, status, totalPeriod) => {
   } else if (status.includes('Halftime') || status.includes('Tipoff')) {
     // game started, clock stopped
     return status
-  } else if (status === 'PPD') {
+  } else if (status === 'PPD' || clock === 'PPD') {
     // PPD mean postponed
     return 'Postponed'
   } else if (

--- a/src/app/utils/convert.js
+++ b/src/app/utils/convert.js
@@ -97,7 +97,7 @@ const getPlayers = (players = []) => {
   }))
 }
 
-const minuteStringRegex = /^(PT)?(\d{1,3})M(\d{1,2})\.(\d{1,2})S$/
+const minuteStringRegex = /^(PT)?(\d+)M(\d+)\.(\d+)S$/
 const formatMinutes = (minute) => {
   let minutes
   let seconds


### PR DESCRIPTION
What
- Fix time duration parsing for ISO 8601. It can have up to 3 digits for minutes
- Fix endpoints. Remove api.boxscores.site because it's not used. Add proxy in case it does not work in the future.
- Add PDD parsing