### PR TITLE
fix: a new api for schedule date for games

### DIFF
--- a/src/app/components/MatchInfo.jsx
+++ b/src/app/components/MatchInfo.jsx
@@ -196,13 +196,13 @@ MatchInfo.propTypes = {
   broadcasters: PropTypes.array,
   home: PropTypes.shape({
     abbreviation: PropTypes.string.isRequired,
-    city: PropTypes.string.isRequired,
+    city: PropTypes.string,
     score: PropTypes.string,
     nickname: PropTypes.string.isRequired,
   }).isRequired,
   visitor: PropTypes.shape({
     abbreviation: PropTypes.string.isRequired,
-    city: PropTypes.string.isRequired,
+    city: PropTypes.string,
     score: PropTypes.string,
     nickname: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/app/components/TeamInfo.jsx
+++ b/src/app/components/TeamInfo.jsx
@@ -39,7 +39,7 @@ const TeamInfo = ({ tid, ta, tn, winning, large, wins, losses, reveal }) => {
           <TeamName winning={spoiler && !reveal ? true : winning}>
             {tn || 'TBD'}
           </TeamName>
-          {wins != null && losses != null && (
+          {(!spoiler || reveal) && wins != null && losses != null && (
             <TeamRecord>
               {wins}-{losses}
             </TeamRecord>

--- a/src/app/containers/Popup/actions.js
+++ b/src/app/containers/Popup/actions.js
@@ -34,6 +34,7 @@ const fetchGames = async (dispatch, dateStr, callback, isBackground) => {
     }
     if (callback) callback(newGames)
   } catch (error) {
+    // debug log here.
     // if any of the fetch requests fail, set the state to error
     if (callback) callback([])
     dispatch({ type: types.REQUEST_ERROR })
@@ -97,28 +98,33 @@ const insertAt = (str, index, text) => {
 
 // new endpoint requires special headers.
 const fetchRequest4 = async (dateStr) => {
-  const newDateStr = insertAt(insertAt(dateStr, 4, '-'), 7, '-')
+  // const newDateStr = insertAt(insertAt(dateStr, 4, '-'), 7, '-')
+  // try {
+  //   const res2 = await fetch(
+  //     `https://proxy.boxscores.site?apiUrl=stats.nba.com/stats/scoreboardv3&GameDate=${newDateStr}&LeagueID=00`
+  //   )
+  //   const {
+  //     scoreboard: { games },
+  //   } = await res2.json()
+  //   g = games
+  // } catch (error) {
+    return fetchRequest5(dateStr);
+  // }
+  // return {
+  //   isFallBack: 3,
+  //   games: g,
+  // }
+}
 
-  let g = []
-  try {
-    const res = await fetch(
-      `https://api.boxscores.site/v1/scoreboard?GameDate=${newDateStr}`
-    )
-    const { games } = await res.json()
-    g = games
-  } catch (error) {
-    const res2 = await fetch(
-      `https://proxy.boxscores.site?apiUrl=stats.nba.com/stats/scoreboardv3&GameDate=${newDateStr}&LeagueID=00`
-    )
-    const {
-      scoreboard: { games },
-    } = await res2.json()
-    g = games
-  }
-
+const fetchRequest5 = async (dateStr) => {
+  const slashDateStr = format(parse(dateStr, DATE_FORMAT, new Date()), 'MM/dd/yyyy');
+  const res = await fetch(
+    `https://proxy.boxscores.site/?apiUrl=core-api.nba.com/cp/api/v1.9/feeds/gamecardfeed&gamedate=${slashDateStr}`
+  )
+  const { cards } = await res.json()
   return {
-    isFallBack: 3,
-    games: g,
+    isFallBack: 5,
+    games: cards,
   }
 }
 

--- a/src/app/containers/Popup/reducers.js
+++ b/src/app/containers/Popup/reducers.js
@@ -29,6 +29,7 @@ export default (state = initState, action) => {
           urls: state.urls,
         }
       } catch (error) {
+        // debug log here
         return {
           games: [],
           hasError: true,

--- a/src/app/utils/games.js
+++ b/src/app/utils/games.js
@@ -2,7 +2,7 @@ import { utcToZonedTime } from 'date-fns-tz'
 import parse from 'date-fns/parse'
 import format from 'date-fns/format'
 import { getUserTimeZoneId } from './time'
-import { convertDaily, convertDaily2, convertDaily3 } from './convert'
+import { convertDaily, convertDaily2, convertDaily3, convertDaily5 } from './convert'
 import getApiDate from './getApiDate'
 
 /**
@@ -45,6 +45,21 @@ import getApiDate from './getApiDate'
       score: string
     }
  */
+
+
+const sanitizeGameFallBack5 = (game) => ({
+  // gives home, visitor
+  ...convertDaily5(game.cardData),
+  id: game.cardData.gameId,
+  date: game.cardData.gameTimeEastern,
+  time: game.cardData.gameTimeEastern,
+  state: game.cardData.gameStatus,
+  arena: {
+    name: '',
+    city: '',
+  },
+  startTimeUTC: game.cardData.gameTimeUtc,
+})
 
 // for https://cdn.nba.com/static/json/liveData/scoreboard/todaysScoreboard_00.json
 /**
@@ -253,6 +268,8 @@ export const sanitizeGames = (games, isFallBack = 0) => {
       return sanitizeGameFallBack2(game)
     } else if (isFallBack === 3) {
       return sanitizeGameFallBack3(game)
+    } else if (isFallBack === 5) {
+      return sanitizeGameFallBack5(game);
     } else {
       return sanitizeGame(game)
     }


### PR DESCRIPTION
What
- Add a new api endpoint for proxy for games of the date
    - keeping old endpoint for historical reason
- Add hiding team records in cards when no-spoiler is on